### PR TITLE
Use logical properties to support RTL and more writing modes

### DIFF
--- a/demo/public/style.css
+++ b/demo/public/style.css
@@ -1,0 +1,11 @@
+body:has(input#rtl:checked) {
+  direction: rtl;
+}
+
+body:has(input#vertical-lr:checked) {
+  writing-mode: vertical-lr;
+}
+
+body:has(input#vertical-rl:checked) {
+  writing-mode: vertical-rl;
+}

--- a/demo/src/layouts/BaseLayout.astro
+++ b/demo/src/layouts/BaseLayout.astro
@@ -7,6 +7,7 @@ const isProd = import.meta.env.PROD;
 <html>
   <head>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="stylesheet" href="/style.css" />
     <meta charset="utf-8" />
     <meta
       name="viewport"
@@ -61,6 +62,20 @@ const isProd = import.meta.env.PROD;
       <slot />
     </main>
     <footer class="flex flex-col items-center gap-4 mt-12">
+      <div>
+        Inline direction:
+        <input type="checkbox" id="rtl" />
+        <label for="rtl">Right to Left</label>
+      </div>
+      <div>
+        Block direction:
+        <input type="radio" id="horizontal" name="layout" value="horizontal" />
+        <label for="horizontal">Horizontal</label>
+        <input type="radio" id="vertical-lr" name="layout" value="vertical-lr" />
+        <label for="vertical-lr">Vertical LR</label>
+        <input type="radio" id="vertical-rl" name="layout" value="vertical-rl" />
+        <label for="vertical-rl">Vertical RL</label>
+      </div>
       <div>
         The source code is available on <a
           class="dark:text-pink-500 text-blue-700"

--- a/packages/astro-tweet/src/twitter-theme/TweetMedia.astro
+++ b/packages/astro-tweet/src/twitter-theme/TweetMedia.astro
@@ -13,19 +13,19 @@ import styles from "./tweet-media.module.css";
 import TweetMediaVideo from "./TweetMediaVideo.astro";
 
 const getSkeletonStyle = (media: MediaDetails, itemCount: number) => {
-  let paddingBottom = 56.25; // default of 16x9
+  let paddingBlockEnd = 56.25; // default of 16x9
 
   // if we only have 1 item, show at original ratio
   if (itemCount === 1)
-    paddingBottom =
+    paddingBlockEnd =
       (100 / media.original_info.width) * media.original_info.height;
 
   // if we have 2 items, double the default to be 16x9 total
-  if (itemCount === 2) paddingBottom = paddingBottom * 2;
+  if (itemCount === 2) paddingBlockEnd = paddingBlockEnd * 2;
 
   return {
     width: media.type === "photo" ? undefined : "unset",
-    paddingBottom: `${paddingBottom}%`,
+    paddingBlockEnd: `${paddingBlockEnd}%`,
   };
 };
 interface Props {

--- a/packages/astro-tweet/src/twitter-theme/TweetSkeleton.astro
+++ b/packages/astro-tweet/src/twitter-theme/TweetSkeleton.astro
@@ -5,19 +5,19 @@ import styles from "./tweet-skeleton.module.css";
 ---
 
 <TweetContainer className={styles.root}>
-  <Skeleton style={{ height: "3rem", marginBottom: "0.75rem" }} />
-  <Skeleton style={{ height: "6rem", margin: "0.5rem 0" }} />
-  <div style={{ borderTop: "var(--tweet-border)", margin: "0.5rem 0" }}></div>
+  <Skeleton style={{ blockSize: "3rem", marginBlockEnd: "0.75rem" }} />
+  <Skeleton style={{ blockSize: "6rem", margin: "0.5rem 0" }} />
+  <div style={{ borderBlockStart: "var(--tweet-border)", marginBlock: "0.5rem", marginInline: "0" }}></div>
   <Skeleton
     style={{
-      height: "2rem",
+      blockSize: "2rem",
     }}
   />
   <Skeleton
     style={{
-      height: "2rem",
+      blockSize: "2rem",
       borderRadius: "9999px",
-      marginTop: "0.5rem",
+      marginBlockStart: "0.5rem",
     }}
   />
 </TweetContainer>

--- a/packages/astro-tweet/src/twitter-theme/icons/icons.module.css
+++ b/packages/astro-tweet/src/twitter-theme/icons/icons.module.css
@@ -1,8 +1,8 @@
 .verified {
-  margin-left: 0.125rem;
+  margin-inline-start: 0.125rem;
   max-width: 20px;
   max-height: 20px;
-  height: 1.25em;
+  block-size: 1.25em;
   fill: currentColor;
   user-select: none;
   vertical-align: text-bottom;

--- a/packages/astro-tweet/src/twitter-theme/quoted-tweet/quoted-tweet-body.module.css
+++ b/packages/astro-tweet/src/twitter-theme/quoted-tweet/quoted-tweet-body.module.css
@@ -5,5 +5,6 @@
   margin: var(--tweet-quoted-body-margin);
   overflow-wrap: break-word;
   white-space: pre-wrap;
-  padding: 0 0.75rem;
+  padding-block: 0;
+  padding-inline: 0.75rem;
 }

--- a/packages/astro-tweet/src/twitter-theme/quoted-tweet/quoted-tweet-container.module.css
+++ b/packages/astro-tweet/src/twitter-theme/quoted-tweet/quoted-tweet-container.module.css
@@ -1,5 +1,5 @@
 .root {
-  width: 100%;
+  inline-size: 100%;
   overflow: hidden;
   border: var(--tweet-border);
   border-radius: 12px;

--- a/packages/astro-tweet/src/twitter-theme/quoted-tweet/quoted-tweet-header.module.css
+++ b/packages/astro-tweet/src/twitter-theme/quoted-tweet/quoted-tweet-header.module.css
@@ -1,6 +1,7 @@
 .header {
   display: flex;
-  padding: 0.75rem 0.75rem 0 0.75rem;
+  padding: 0.75rem;
+  padding-block-end: 0;
   line-height: var(--tweet-header-line-height);
   font-size: var(--tweet-header-font-size);
   white-space: nowrap;
@@ -10,8 +11,8 @@
 
 .avatar {
   position: relative;
-  height: 20px;
-  width: 20px;
+  block-size: 20px;
+  inline-size: 20px;
 }
 
 .avatarSquare {
@@ -20,7 +21,8 @@
 
 .author {
   display: flex;
-  margin: 0 0.5rem;
+  margin-block: 0;
+  margin-inline: 0.5rem;
 }
 
 .authorText {
@@ -34,5 +36,5 @@
   color: var(--tweet-font-color-secondary);
   text-decoration: none;
   text-overflow: ellipsis;
-  margin-left: 0.125rem;
+  margin-inline-start: 0.125rem;
 }

--- a/packages/astro-tweet/src/twitter-theme/skeleton.module.css
+++ b/packages/astro-tweet/src/twitter-theme/skeleton.module.css
@@ -1,6 +1,6 @@
 .skeleton {
   display: block;
-  width: 100%;
+  inline-size: 100%;
   border-radius: 5px;
   background-image: var(--tweet-skeleton-gradient);
   background-size: 400% 100%;

--- a/packages/astro-tweet/src/twitter-theme/tweet-actions.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-actions.module.css
@@ -2,9 +2,9 @@
   display: flex;
   align-items: center;
   color: var(--tweet-font-color-secondary);
-  padding-top: 0.25rem;
-  margin-top: 0.25rem;
-  border-top: var(--tweet-border);
+  padding-block-start: 0.25rem;
+  margin-block-start: 0.25rem;
+  border-block-start: var(--tweet-border);
   overflow-wrap: break-word;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -17,7 +17,7 @@
   color: inherit;
   display: flex;
   align-items: center;
-  margin-right: 1.25rem;
+  margin-inline-end: 1.25rem;
 }
 .like:hover,
 .reply:hover,
@@ -34,18 +34,18 @@
 .likeIconWrapper,
 .replyIconWrapper,
 .copyIconWrapper {
-  width: var(--tweet-actions-icon-wrapper-size);
-  height: var(--tweet-actions-icon-wrapper-size);
+  inline-size: var(--tweet-actions-icon-wrapper-size);
+  block-size: var(--tweet-actions-icon-wrapper-size);
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-left: -0.25rem;
+  margin-inline-start: -0.25rem;
   border-radius: 9999px;
 }
 .likeIcon,
 .replyIcon,
 .copyIcon {
-  height: var(--tweet-actions-icon-size);
+  block-size: var(--tweet-actions-icon-size);
   fill: currentColor;
   user-select: none;
 }
@@ -58,7 +58,7 @@
   font-size: var(--tweet-actions-font-size);
   font-weight: var(--tweet-actions-font-weight);
   line-height: var(--tweet-actions-line-height);
-  margin-left: 0.25rem;
+  margin-inline-start: 0.25rem;
 }
 
 .reply:hover > .replyIconWrapper {

--- a/packages/astro-tweet/src/twitter-theme/tweet-container.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-container.module.css
@@ -1,7 +1,7 @@
 .root {
-  width: 100%;
-  min-width: 250px;
-  max-width: 550px;
+  inline-size: 100%;
+  min-inline-size: 250px;
+  max-inline-size: 550px;
   overflow: hidden;
   /* Base font styles */
   color: var(--tweet-font-color);
@@ -21,5 +21,6 @@
 .article {
   position: relative;
   box-sizing: inherit;
-  padding: 0.75rem 1rem;
+  padding-block: 0.75rem;
+  padding-inline: 1rem;
 }

--- a/packages/astro-tweet/src/twitter-theme/tweet-header.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-header.module.css
@@ -1,6 +1,6 @@
 .header {
   display: flex;
-  padding-bottom: 0.75rem;
+  padding-block-end: 0.75rem;
   line-height: var(--tweet-header-line-height);
   font-size: var(--tweet-header-font-size);
   white-space: nowrap;
@@ -10,12 +10,12 @@
 
 .avatar {
   position: relative;
-  height: 48px;
-  width: 48px;
+  block-size: 48px;
+  inline-size: 48px;
 }
 .avatarOverflow {
-  height: 100%;
-  width: 100%;
+  block-size: 100%;
+  inline-size: 100%;
   position: absolute;
   overflow: hidden;
   border-radius: 9999px;
@@ -24,8 +24,8 @@
   border-radius: 4px;
 }
 .avatarShadow {
-  height: 100%;
-  width: 100%;
+  block-size: 100%;
+  inline-size: 100%;
   transition-property: background-color;
   transition-duration: 0.2s;
   box-shadow: rgb(0 0 0 / 3%) 0px 0px 2px inset;
@@ -35,11 +35,12 @@
 }
 
 .author {
-  max-width: calc(100% - 84px);
+  max-inline-size: calc(100% - 84px);
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin: 0 0.5rem;
+  margin-block: 0;
+  margin-inline: 0.5rem;
 }
 .authorLink {
   text-decoration: none;
@@ -80,7 +81,8 @@
   text-decoration-line: underline;
 }
 .separator {
-  padding: 0 0.25rem;
+  padding-block: 0;
+  padding-inline: 0.25rem;
 }
 
 .brand {
@@ -88,8 +90,8 @@
 }
 
 .twitterIcon {
-  width: 23.75px;
-  height: 23.75px;
+  inline-size: 23.75px;
+  block-size: 23.75px;
   color: var(--tweet-twitter-icon-color);
   fill: currentColor;
   user-select: none;

--- a/packages/astro-tweet/src/twitter-theme/tweet-in-reply-to.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-in-reply-to.module.css
@@ -3,7 +3,7 @@
   color: var(--tweet-font-color-secondary);
   font-size: 0.9375rem;
   line-height: 1.25rem;
-  margin-bottom: 0.25rem;
+  margin-block-end: 0.25rem;
   overflow-wrap: break-word;
   white-space: pre-wrap;
 }

--- a/packages/astro-tweet/src/twitter-theme/tweet-info.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-info.module.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   color: var(--tweet-font-color-secondary);
-  margin-top: 0.125rem;
+  margin-block-start: 0.125rem;
   overflow-wrap: break-word;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -12,14 +12,14 @@
   text-decoration: none;
 }
 .infoLink {
-  height: var(--tweet-actions-icon-wrapper-size);
-  width: var(--tweet-actions-icon-wrapper-size);
+  block-size: var(--tweet-actions-icon-wrapper-size);
+  inline-size: var(--tweet-actions-icon-wrapper-size);
   font: inherit;
-  margin-left: auto;
+  margin-inline-start: auto;
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-right: -4px;
+  margin-inline-end: -4px;
   border-radius: 9999px;
   transition-property: background-color;
   transition-duration: 0.2s;
@@ -30,7 +30,7 @@
 .infoIcon {
   color: inherit;
   fill: currentColor;
-  height: var(--tweet-actions-icon-size);
+  block-size: var(--tweet-actions-icon-size);
   user-select: none;
 }
 .infoLink:hover > .infoIcon {

--- a/packages/astro-tweet/src/twitter-theme/tweet-media-video.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-media-video.module.css
@@ -2,7 +2,8 @@
   display: flex;
   align-items: center;
   color: white;
-  padding: 0 1rem;
+  padding-block: 0;
+  padding-inline: 1rem;
   border: 1px solid transparent;
   border-radius: 9999px;
   font-weight: 700;
@@ -16,8 +17,8 @@
 }
 .videoButton {
   position: relative;
-  height: 67px;
-  width: 67px;
+  block-size: 67px;
+  inline-size: 67px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -33,22 +34,22 @@
   background-color: var(--tweet-color-blue-primary-hover);
 }
 .videoButtonIcon {
-  margin-left: 3px;
-  width: calc(50% + 4px);
-  height: calc(50% + 4px);
-  max-width: 100%;
+  margin-inline-start: 3px;
+  inline-size: calc(50% + 4px);
+  block-size: calc(50% + 4px);
+  max-inline-size: 100%;
   color: #fff;
   fill: currentColor;
   user-select: none;
 }
 .watchOnTwitter {
   position: absolute;
-  top: 12px;
-  right: 8px;
+  inset-block-start: 12px;
+  inset-inline-end: 8px;
 }
 .watchOnTwitter > a {
-  min-width: 2rem;
-  min-height: 2rem;
+  min-inline-size: 2rem;
+  min-block-size: 2rem;
   font-size: 0.875rem;
   line-height: 1rem;
   backdrop-filter: blur(4px);
@@ -59,7 +60,7 @@
 }
 .viewReplies {
   position: relative;
-  min-height: 2rem;
+  min-block-size: 2rem;
   background-color: var(--tweet-color-blue-primary);
   border-color: var(--tweet-color-blue-primary);
   font-size: 0.9375rem;

--- a/packages/astro-tweet/src/twitter-theme/tweet-media.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-media.module.css
@@ -1,5 +1,5 @@
 .root {
-  margin-top: 0.75rem;
+  margin-block-start: 0.75rem;
   overflow: hidden;
   position: relative;
 }
@@ -11,8 +11,8 @@
   display: grid;
   grid-auto-rows: 1fr;
   gap: 2px;
-  height: 100%;
-  width: 100%;
+  block-size: 100%;
+  inline-size: 100%;
 }
 .grid2Columns {
   grid-template-columns: repeat(2, 1fr);
@@ -25,8 +25,8 @@
 }
 .mediaContainer {
   position: relative;
-  height: 100%;
-  width: 100%;
+  block-size: 100%;
+  inline-size: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -36,17 +36,17 @@
   outline-style: none;
 }
 .skeleton {
-  padding-bottom: 56.25%;
-  width: 100%;
+  padding-block-end: 56.25%;
+  inline-size: 100%;
   display: block;
 }
 .image {
   position: absolute;
-  top: 0px;
-  left: 0px;
-  bottom: 0px;
-  height: 100%;
-  width: 100%;
+  inset-block-start: 0px;
+  inset-inline-start: 0px;
+  inset-block-end: 0px;
+  block-size: 100%;
+  inline-size: 100%;
   margin: 0;
   object-fit: cover;
   object-position: center;

--- a/packages/astro-tweet/src/twitter-theme/tweet-not-found.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-not-found.module.css
@@ -2,9 +2,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-bottom: 0.75rem;
+  padding-block-end: 0.75rem;
 }
 .root > h3 {
   font-size: 1.25rem;
-  margin-bottom: 0.5rem;
+  margin-block-end: 0.5rem;
 }

--- a/packages/astro-tweet/src/twitter-theme/tweet-replies.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-replies.module.css
@@ -1,5 +1,6 @@
 .replies {
-  padding: 0.25rem 0;
+  padding-block: 0.25rem;
+  padding-inline: 0;
 }
 .link {
   text-decoration: none;
@@ -7,13 +8,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 32px;
-  min-height: 32px;
+  min-inline-size: 32px;
+  min-block-size: 32px;
   user-select: none;
   outline-style: none;
   transition-property: background-color;
   transition-duration: 0.2s;
-  padding: 0 1rem;
+  padding-block: 0;
+  padding-inline: 1rem;
   border: var(--tweet-border);
   border-radius: 9999px;
 }

--- a/packages/astro-tweet/src/twitter-theme/tweet-skeleton.module.css
+++ b/packages/astro-tweet/src/twitter-theme/tweet-skeleton.module.css
@@ -1,4 +1,4 @@
 .root {
   pointer-events: none;
-  padding-bottom: 0.25rem;
+  padding-block-end: 0.25rem;
 }


### PR DESCRIPTION
This PR replaces physical properties with [logical](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values) ones to enhance support for languages that are not left-to-right (LTR).

I’ve updated the demo to showcase different options:

![](https://github.com/user-attachments/assets/9e3f1c9a-ec29-492f-b344-ecb904f91fd5)
![png (14)](https://github.com/user-attachments/assets/4ab825e3-c604-4380-9e2f-8857b0e2f51f)
![png (15)](https://github.com/user-attachments/assets/a5ccdc4e-35cd-45b2-9d68-d247f830d05f)

While logical properties are not new, frameworks like Tailwind have only recently begun incorporating them more extensively. The properties used in this PR require Chromium 87+ (released on 2020-11-17). If backward compatibility or upstream mergability is a concern, feel free to skip this PR :-) Another option is to use the [PostCSS Logical Properties and Values](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-logical) plugin for fallback support if you’re working in an LTR-only environment.

Additionally, I suggest we consider adding i18n features, or at least allowing users to customize button text.