### PR TITLE
Handle tombstones

### DIFF
--- a/.changeset/thin-waves-dance.md
+++ b/.changeset/thin-waves-dance.md
@@ -1,0 +1,5 @@
+---
+"astro-tweet": patch
+---
+
+Handle TweetTombstone result coming from Twitter API.

--- a/packages/astro-tweet/src/api/get-tweet.ts
+++ b/packages/astro-tweet/src/api/get-tweet.ts
@@ -70,6 +70,7 @@ export async function getTweet(
   const isJson = res.headers.get("content-type")?.includes("application/json");
   const data = isJson ? await res.json() : undefined;
 
+  if (res.ok && data.__typename === "TweetTombstone") throw new TwitterApiError({ message: "This tweet is unavailable.", status: res.status, data });
   if (res.ok) return data;
   if (res.status === 404) return;
 


### PR DESCRIPTION
Twitter API can return `{ __typename: 'TweetTombstone' }` as a result for tweet query and `astro-tweet` just throws unhandled error in this case. As far as I understand API might return it in case when tweet is considered as NSFW content.

`react-tweet` lib [handles such result too](https://github.com/vercel/react-tweet/blob/e012477c8485508bf69bd1dfd77888c18d6fab6e/packages/react-tweet/src/api/fetch-tweet.ts#L74-L76) by providing tombstone component. We can do it in the same way, but this PR is focused on quick fix — it just catches such query result and throws `TwitterApiError`, with message `This tweet is unavailable.`.

**Example of such tweet** (it's not mine): https://x.com/hyperion_xyz/status/1938112894522228775

**When you are authorized you see:** 
<img width="596" height="809" alt="image" src="https://github.com/user-attachments/assets/52d91f12-c285-46ed-bb9f-02a2c06f51a7" />
But if you try open it in incognito mode you'll get
<img width="598" height="162" alt="image" src="https://github.com/user-attachments/assets/e4aa9724-6502-4100-ad9f-5bf792f36b10" />


