### PR TITLE
Fix entities not iterable

### DIFF
--- a/packages/astro-tweet/src/utils.ts
+++ b/packages/astro-tweet/src/utils.ts
@@ -120,13 +120,11 @@ function getEntities(tweet: TweetBase): Entity[] {
     { indices: tweet.display_text_range, type: "text" },
   ];
 
-  addEntities(result, "hashtag", tweet.entities.hashtags);
-  addEntities(result, "mention", tweet.entities.user_mentions);
-  addEntities(result, "url", tweet.entities.urls);
-  addEntities(result, "symbol", tweet.entities.symbols);
-  if (tweet.entities.media) {
-    addEntities(result, "media", tweet.entities.media);
-  }
+  addEntities(result, "hashtag", tweet.entities.hashtags ?? []);
+  addEntities(result, "mention", tweet.entities.user_mentions ?? []);
+  addEntities(result, "url", tweet.entities.urls ?? []);
+  addEntities(result, "symbol", tweet.entities.symbols ?? []);
+  addEntities(result, "media", tweet.entities.media ?? []);
   fixRange(tweet, result);
 
   return result.map((entity) => {


### PR DESCRIPTION
### Problem

Some responses from the X/Twitter syndication API omit empty entity arrays such as `hashtags`, `user_mentions`, `urls`, `symbols`, or `media`.

`astro-tweet` currently assumes those fields are always iterable and passes them directly into `addEntities()`. When any field is missing, rendering fails with:

```
TypeError: entities is not iterable
```

This can break pages that embed otherwise valid tweets whose syndication payload simply omits empty entity collections.

### Solution

Default missing tweet entity collections to empty arrays before passing them to `addEntities()`.

This preserves the existing rendering behavior for tweets with entities, while allowing tweets without specific entity types to render normally.